### PR TITLE
cli: add ssh-monitor and connection commands for dynamic eBPF tracking

### DIFF
--- a/core/common.go
+++ b/core/common.go
@@ -9,17 +9,24 @@ import (
 
 	"github.com/cilium/ebpf"
 	"github.com/cilium/ebpf/link"
+	"os/signal"
+"syscall"
+
 )
 
-func runMonitor(path, progName, mapName, hookType, hookName string) {
+func runMonitor(path, progName, mapName, hookType, hookFunc string) {
+	fmt.Printf("Starting monitor: %s → %s:%s\n", progName, hookType, hookFunc)
+
+	// Read eBPF object
 	data, err := os.ReadFile(path)
 	if err != nil {
 		log.Fatalf("Failed to read eBPF object: %v", err)
 	}
 
+	// Load BPF
 	spec, err := ebpf.LoadCollectionSpecFromReader(bytes.NewReader(data))
 	if err != nil {
-		log.Fatalf("Failed to load eBPF spec from %s: %v", path, err)
+		log.Fatalf("Failed to load eBPF spec: %v", err)
 	}
 
 	coll, err := ebpf.NewCollection(spec)
@@ -28,51 +35,65 @@ func runMonitor(path, progName, mapName, hookType, hookName string) {
 	}
 	defer coll.Close()
 
+	// Get program
 	prog, ok := coll.Programs[progName]
 	if !ok {
-		log.Fatalf("Program %s not found in %s", progName, path)
+		log.Fatalf("Program %s not found", progName)
 	}
 	defer prog.Close()
 
+	// Attach hook
+	var lk link.Link
+	if hookType == "kprobe" {
+		lk, err = link.Kprobe(hookFunc, prog, nil)
+	} else {
+		lk, err = link.Tracepoint("syscalls", hookFunc, prog, nil)
+	}
+	if err != nil {
+		log.Fatalf("Failed to attach: %v", err)
+	}
+	defer lk.Close()
+
+	// Get map
 	m, ok := coll.Maps[mapName]
 	if !ok {
-		log.Fatalf("Map %s not found in %s", mapName, path)
+		log.Fatalf("Map %s not found", mapName)
 	}
 	defer m.Close()
 
-	var lnk link.Link
+	fmt.Println("eBPF attached. Watching...")
 
-	switch hookType {
-	case "tracepoint":
-		lnk, err = link.Tracepoint("syscalls", hookName, prog, nil)
-	case "kprobe":
-		lnk, err = link.Kprobe(hookName, prog, nil)
-	default:
-		log.Fatalf("Unsupported hook type: %s", hookType)
-	}
-	if err != nil {
-		log.Fatalf("Failed to attach %s: %v", hookName, err)
-	}
-	defer lnk.Close()
+	// Print every 3 sec
+	ticker := time.NewTicker(3 * time.Second)
+	defer ticker.Stop()
 
-	fmt.Printf("eBPF loaded: %s → %s:%s\n", progName, hookType, hookName)
+	sig := make(chan os.Signal, 1)
+	signal.Notify(sig, syscall.SIGINT, syscall.SIGTERM)
 
 	for {
-		time.Sleep(3 * time.Second)
+		select {
+		case <-ticker.C:
+			var (
+				key   uint32
+				value uint32
+				iter  = m.Iterate()
+				total uint32 = 0
+			)
 
-		var (
-			key   uint32
-			value uint32
-			iter  = m.Iterate()
-		)
+			fmt.Printf("[%s] PID -> Attempts:\n", mapName)
+			for iter.Next(&key, &value) {
+				fmt.Printf("  %d -> %d\n", key, value)
+				total += value
+			}
+			fmt.Printf("[%s] Total Attempts: %d\n\n", mapName, total)
 
-		fmt.Printf("[%s] PID -> Count:\n", mapName)
-		for iter.Next(&key, &value) {
-			fmt.Printf("  %d -> %d\n", key, value)
-		}
+			if err := iter.Err(); err != nil {
+				log.Printf("Iteration error: %v", err)
+			}
 
-		if err := iter.Err(); err != nil {
-			log.Printf("[%s] iteration error: %v", mapName, err)
+		case <-sig:
+			fmt.Println("Monitor stopped")
+			return
 		}
 	}
 }

--- a/core/ssh.go
+++ b/core/ssh.go
@@ -1,9 +1,11 @@
 package core
 
 import (
+	
 )
 
 func RunSSHMonitor() {
 	runMonitor("bin/ssh_monitor.o", "count_ssh", "ssh_attempts", "kprobe", "sys_connect")
 }
+
 


### PR DESCRIPTION
- Added `ssh-monitor` and `connections` subcommands using Cobra CLI
- Introduced `core/common.go` with shared `runMonitor` function to support dynamic eBPF probe execution
- Commands support real-time tracking of SSH and network connection attempts via eBPF programs
- Added signal handling for graceful termination
- Minor fixes in import paths and cleanup of agent structure

Note:
- eBPF object files must be placed in `bin/`
- Program names and map names must match those defined in the `.c` source